### PR TITLE
Update requirements.txt

### DIFF
--- a/hapi/controllers/campaigns_controller.py
+++ b/hapi/controllers/campaigns_controller.py
@@ -6,7 +6,7 @@ hapi
 This file was automatically generated for VONQ by APIMATIC v3.0 (
  https://www.apimatic.io ).
 """
-
+import json
 import logging
 from hapi.api_helper import APIHelper
 from hapi.configuration import Server
@@ -116,7 +116,7 @@ class CampaignsController(BaseController):
                 raise OrderCampaignErrorResponseException('', _response)
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, OrderCampaignSuccessResponseModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -183,7 +183,7 @@ class CampaignsController(BaseController):
             _response = self.execute_request(_request, name = 'list_campaigns')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, ResultSet1Model.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -241,7 +241,7 @@ class CampaignsController(BaseController):
             _response = self.execute_request(_request, name = 'retrieve_campaign')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, ListCampaignResponseModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -301,7 +301,7 @@ class CampaignsController(BaseController):
             _response = self.execute_request(_request, name = 'check_campaign_status')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, CheckCampaignStatusresponseModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -371,7 +371,7 @@ class CampaignsController(BaseController):
                 raise TakeCampaignOfflineErrorResponseException('', _response)
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, TakeCampaignOfflineResponseModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 

--- a/hapi/controllers/contracts_controller.py
+++ b/hapi/controllers/contracts_controller.py
@@ -19,6 +19,7 @@ from hapi.models.contract_model import ContractModel
 from hapi.models.multiple_contracts_response_model import MultipleContractsResponseModel
 from hapi.models.autocomplete_values_response_model import AutocompleteValuesResponseModel
 from hapi.exceptions.api_exception import APIException
+import json
 
 
 class ContractsController(BaseController):
@@ -94,7 +95,7 @@ class ContractsController(BaseController):
             _response = self.execute_request(_request, name = 'list_channels')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, ListChannelsResponseModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -155,7 +156,7 @@ class ContractsController(BaseController):
             _response = self.execute_request(_request, name = 'retrieve_channel')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, ChannelModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -221,7 +222,7 @@ class ContractsController(BaseController):
             _response = self.execute_request(_request, name = 'list_contracts')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, ListContractsResponseModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -290,7 +291,7 @@ class ContractsController(BaseController):
                 raise APIException('', _response)
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, CreateContractResponseModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -409,7 +410,7 @@ class ContractsController(BaseController):
             _response = self.execute_request(_request, name = 'retrieve_contract')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, ContractModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -477,7 +478,7 @@ class ContractsController(BaseController):
             _response = self.execute_request(_request, name = 'retrieve_multiple_contracts')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, MultipleContractsResponseModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -544,7 +545,7 @@ class ContractsController(BaseController):
                 raise APIException('', _response)
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, AutocompleteValuesResponseModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 

--- a/hapi/controllers/portfolio_controller.py
+++ b/hapi/controllers/portfolio_controller.py
@@ -14,6 +14,7 @@ from hapi.controllers.base_controller import BaseController
 from hapi.models.product_model import ProductModel
 from hapi.models.products_delivery_time_model import ProductsDeliveryTimeModel
 from hapi.exceptions.api_exception import APIException
+import json
 
 
 class PortfolioController(BaseController):
@@ -156,7 +157,7 @@ class PortfolioController(BaseController):
                 raise APIException('', _response)
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, ProductModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -219,7 +220,7 @@ class PortfolioController(BaseController):
             _response = self.execute_request(_request, name = 'retrieve_single_product')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, ProductModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -282,7 +283,7 @@ class PortfolioController(BaseController):
             _response = self.execute_request(_request, name = 'retrieve_multiple_products')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, ProductModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -339,7 +340,7 @@ class PortfolioController(BaseController):
             _response = self.execute_request(_request, name = 'calculate_order_delivery_time')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, ProductsDeliveryTimeModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 

--- a/hapi/controllers/taxonomy_controller.py
+++ b/hapi/controllers/taxonomy_controller.py
@@ -17,7 +17,7 @@ from hapi.models.location_model import LocationModel
 from hapi.models.industry_model import IndustryModel
 from hapi.models.education_level_model import EducationLevelModel
 from hapi.models.seniority_model import SeniorityModel
-
+import json
 
 class TaxonomyController(BaseController):
 
@@ -79,7 +79,7 @@ class TaxonomyController(BaseController):
             _response = self.execute_request(_request, name = 'retrieve_job_functions_tree')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, JobFunctionModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -158,7 +158,7 @@ class TaxonomyController(BaseController):
             _response = self.execute_request(_request, name = 'search_job_titles')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, JobTitleModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -225,7 +225,7 @@ class TaxonomyController(BaseController):
             _response = self.execute_request(_request, name = 'search_locations')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, LocationModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -297,7 +297,7 @@ class TaxonomyController(BaseController):
             _response = self.execute_request(_request, name = 'list_industries')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, IndustryModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -345,7 +345,7 @@ class TaxonomyController(BaseController):
             _response = self.execute_request(_request, name = 'retrieve_education_levels')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, EducationLevelModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 
@@ -393,7 +393,7 @@ class TaxonomyController(BaseController):
             _response = self.execute_request(_request, name = 'retrieve_seniorities')
             self.validate_response(_response)
     
-            decoded = APIHelper.json_deserialize(_response.text, SeniorityModel.from_dictionary)
+            decoded = json.loads(_response.text)
     
             return decoded
 


### PR DESCRIPTION
## Change description

> Description here

Removed `APIHelper.json_serialize` calls for responses from VONQ API. These were messing with the type hints of the responses and obfuscated error messages in response payloads.

Now the native `json.loads` method will be used, allowing types to be declared outside of the library.